### PR TITLE
feat: use noble/hashes instead of keccak module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var createKeccakHash = require('keccak')
+var keccak256 = require('@noble/hashes/sha3').keccak_256
 
 function encodeInternal (address, parsed, chainId) {
   checkChainId(chainId)
@@ -9,9 +9,7 @@ function encodeInternal (address, parsed, chainId) {
   var forHash = chainId !== undefined
     ? chainId.toString(10) + '0x' + addressHex
     : addressHex
-  var checksum = createKeccakHash('keccak256')
-    .update(forHash)
-    .digest()
+  var checksum = keccak256(forHash)
 
   var ret = '0x'
   for (var i = 0; i < 20; ++i) {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "keccak": "^3.0.3"
+    "@noble/hashes": "^1.3.3"
   },
   "devDependencies": {
+    "keccak": "^3.0.3",
     "nyc": "^15.1.0",
     "standard": "^12.0.1",
     "tape": "^4.8.0"


### PR DESCRIPTION
Tests left as they are, to compare with `keccak` which is now a dev dep only